### PR TITLE
Fixed broken device token strings

### DIFF
--- a/LigerMobile/Startup/LGRAppDelegate.m
+++ b/LigerMobile/Startup/LGRAppDelegate.m
@@ -47,9 +47,9 @@
 	for (NSUInteger i=0; i < length/4 + !!(length%4); i++) {
 		UInt8 *bytes = (UInt8*)&a[i];
 #ifdef __BIG__ENDIAN__
-		token = [token stringByAppendingFormat:@"%x%x%x%x", bytes[0], bytes[1], bytes[2], bytes[3]];
+		token = [token stringByAppendingFormat:@"%02x%02x%02x%02x", bytes[0], bytes[1], bytes[2], bytes[3]];
 #elif __LITTLE_ENDIAN__
-		token = [token stringByAppendingFormat:@"%x%x%x%x", bytes[3], bytes[2], bytes[1], bytes[0]];
+		token = [token stringByAppendingFormat:@"%02x%02x%02x%02x", bytes[3], bytes[2], bytes[1], bytes[0]];
 #endif
 	}
 

--- a/LigerTestApp/LigerTests/Startup/LGRAppDelegateTest.m
+++ b/LigerTestApp/LigerTests/Startup/LGRAppDelegateTest.m
@@ -21,12 +21,12 @@
 @end
 
 NSData* testToken() {
-	int32_t hexData[8] = {0x26ea0f58, 0x99ac6bd8, 0xa3e0d6b5, 0x1f38a4ad, 0x3475c1e4, 0xeefbeee6, 0x2eca722c, 0xef0c3bf9};
+	int32_t hexData[8] = {0x260a0f58, 0x99ac6bd8, 0xa3e0d6b5, 0x1f38a4ad, 0x3475c1e4, 0xeefbeee6, 0x2eca722c, 0xef0c3bf9};
 	return [NSData dataWithBytes:hexData length:32];
 }
 
 NSString* testTokenAsString() {
-	return @"26eaf5899ac6bd8a3e0d6b51f38a4ad3475c1e4eefbeee62eca722cefc3bf9";
+	return @"260a0f5899ac6bd8a3e0d6b51f38a4ad3475c1e4eefbeee62eca722cef0c3bf9";
 }
 
 @implementation LGRAppDelegateTest
@@ -41,6 +41,11 @@ NSString* testTokenAsString() {
 - (void)testInit
 {
 	XCTAssertNotNil([[LGRAppDelegate alloc] init], @"Failed to init");
+}
+
+- (void)testTestToken
+{
+	XCTAssertTrue([testTokenAsString() length] == 64, @"Test string should be 64 long");
 }
 
 - (void)testDidFinishLaunchingWithOptions


### PR DESCRIPTION
Fixed values lower than 10 not rendering correctly for device token strings.

Fixes #99 